### PR TITLE
Lazily load nvm

### DIFF
--- a/nvmish.sh
+++ b/nvmish.sh
@@ -12,8 +12,13 @@
 function load_nvm_once() {
   local NVM_SOURCED=$(command -v 'nvm')
   if [[ -z "$NVM_SOURCED" ]]; then
-    echo 'Sourcing NVM'
-    source $(brew --prefix nvm)/nvm.sh
+    if [[ -z "$NVM_DIR" ]]; then
+      echo 'Unable to lazy load nvm because envvar $NVM_DIR not set'
+      exit 1
+    else
+      echo 'Sourcing NVM'
+      source "$NVM_DIR/nvm.sh"
+    fi
   fi
 }
 

--- a/nvmish.sh
+++ b/nvmish.sh
@@ -8,7 +8,14 @@
 # 1 No package.json in current directory
 # 2 Found package.json but no engines specified
 
-source $(brew --prefix nvm)/nvm.sh
+# Only source nvm if its not already loaded
+function load_nvm_once() {
+  local NVM_SOURCED=$(command -v 'nvm')
+  if [[ -z "$NVM_SOURCED" ]]; then
+    echo 'Sourcing NVM'
+    source $(brew --prefix nvm)/nvm.sh
+  fi
+}
 
 function nvmish() {
   if [[ ! -f package.json ]] ; then
@@ -24,6 +31,7 @@ function nvmish() {
   local NVM_VERSION_DIR
   local IOJS_VERSION=$(cat package.json | jq --raw-output .engines.iojs)
   if [[ "$IOJS_VERSION" != "null" ]] ; then
+    load_nvm_once
     if ! [[ "$IOJS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       IOJS_VERSION=$(curl --silent --get --data-urlencode "range=${IOJS_VERSION}" https://semver.herokuapp.com/iojs/resolve)
     fi
@@ -41,6 +49,7 @@ function nvmish() {
   
   local NODE_VERSION=$(cat package.json | jq --raw-output .engines.node)
   if [[ "$NODE_VERSION" != "null" ]] ; then
+    load_nvm_once
     if ! [[ "$NODE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       NODE_VERSION=$(curl --silent --get --data-urlencode "range=${NODE_VERSION}" https://semver.herokuapp.com/node/resolve)
     fi


### PR DESCRIPTION
## WIP -- DO NOT MERGE

My unscientific discovery from trying to replace nvmish is that there's still a significant load time penalty for every new shell created. This seems to be caused by loading the thousands of lines of nvm bash into the shell.

This PR somewhat improves shell load time by lazily loading nvm, allowing shells that don't need nvm to start a bit faster.

@bobzoller @serhalp 
