### PR TITLE
Use TJ's n script as a replacement for nvm

### DIFF
--- a/nvmish.sh
+++ b/nvmish.sh
@@ -1,13 +1,11 @@
 # adapted from https://gist.github.com/assaf/ee377a186371e2e269a7
-# requires nvm and jq
+# requires n and jq
 
 # Install nodejs/npm version specified in package.json
 #
-# Exit code:
-# 0 Successfully installed and using the desired version
-# 1 No package.json in current directory
+# Source this file in your profile to get node/npm installed when you cd into a directory with a package.json.
 
-function __nvmish_needs_resolution() {
+function __nish_needs_resolution() {
   local semver=$1
   if ! [[ "$semver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     return 0
@@ -16,28 +14,10 @@ function __nvmish_needs_resolution() {
   fi
 }
 
-function __nvmish_install_nodejs() {
+function __nish_install_npm() {
   local version="$1"
 
-  if __nvmish_needs_resolution "$version"; then
-    version=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.io/node/resolve)
-  fi
-  local nvm_version="v$version"
-  local nvm_new_version_dir="$NVM_DIR/versions/node/$nvm_version"
-  local nvm_old_version_dir="$NVM_DIR/$nvm_version"
-  if [[ ! -d "$nvm_old_version_dir" && ! -d "$nvm_new_version_dir" ]]; then
-    echo "Installing node v$version ..."
-    nvm install $nvm_version
-  else
-    nvm use $nvm_version
-  fi
-  return $?
-}
-
-function __nvmish_install_npm() {
-  local version="$1"
-
-  if __nvmish_needs_resolution "$version"; then
+  if __nish_needs_resolution "$version"; then
     version=$(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=${version}" https://semver.io/npm/resolve)
   fi
 
@@ -52,40 +32,25 @@ function __nvmish_install_npm() {
   return $?
 }
 
-function nvmish() {
+function nish() {
   if [[ ! -f package.json ]] ; then
-    if [[ "$1" != "chpwd" ]] ; then
-      echo "No package.json found in current directory"
-      return 1
-    else
-      return 0
-    fi
+    return 0
   fi
 
   local blessed_nodejs_version=4
   local desired_nodejs_version=$(cat package.json | jq --raw-output .engines.node)
   [[ "$desired_nodejs_version" == "null" ]] && desired_nodejs_version="$blessed_nodejs_version"
-  __nvmish_install_nodejs "$desired_nodejs_version" || return $?
+  n "$desired_nodejs_version" || return $?
 
   local blessed_npm_version=3.9
   local desired_npm_version=$(cat package.json | jq --raw-output .engines.npm)
   [[ "$desired_npm_version" == "null" ]] && desired_npm_version="$blessed_npm_version"
-  __nvmish_install_npm "$desired_npm_version" || return $?
+  __nish_install_npm "$desired_npm_version" || return $?
 
   return 0
 }
 
-
-# This whole chpwd support business was lovingly borrowed from rvm.
-__dirname=$(brew --prefix nvmish)
-
-source $__dirname/vendor/bash_zsh_support/chpwd/function.sh
-source $__dirname/vendor/bash_zsh_support/chpwd/load.sh
-
-function __nvmish() {
-  nvmish "chpwd"
+function cd() {
+  builtin cd "$@";
+  nish
 }
-
-[[ " ${chpwd_functions[*]} " == *" __nvmish "* ]] ||
-  chpwd_functions=( "${chpwd_functions[@]}" __nvmish )
-


### PR DESCRIPTION
## WARNING -- NOT READY FOR PRIMETIME, DON'T MERGE THIS TO MASTER!

nvm/nvmish has been really useful for managing different versions of node (and now npm :+1:) automatically without complicated docker workflows or greedy virtual machines. In particular, having the current shell automatically use and/or install the correct version of node in any particular project prevents a whole set of error-prone manual management of the environment, increasing code quality and developer productivity in one fell swoop.

However, there is a small downside to this system: starting new shells is fairly slow, sometimes requiring tens of seconds. There are two causes of this:

 1. We rely on large pieces of RVM's bash scripts to tap into the cd command. This script is large and takes several seconds to load into bash each time a new shell session is spawned.
 2. To actually install or change the current shell's version of nodejs, we leveral NVM which is also a several thousand line bash script which requires several seconds to load as well. NVM must be loaded into the shell to setup each shell independently.

This PR tries to tackle both issues:

 1. I've written a tiny shell function which wraps `cd` and allows us to check the environment every time we change directories. This reduces the dependency on the RVM scripts we were previously loading. It works in bash and zsh, and could be adopted independent of anything else in this PR :-)
 2. I've taken a stab at using TJ's leaner version of nvm called `n`. `n` doesn't have to be loaded into your shell, its installed into your path (/usr/local/bin). This addresses issue 2.

Blockers on this:

 * [ ] scope node version to the shell. This means if you start garbanzo in one shell, and kale in another shell, the garbanzo shell will have the kale version node for the next command run. @demands proposed mucking with the `$PATH` to resolve this.

@demands @bobzoller @sylspren 