### PR TITLE
Make nvmish less noisy

### DIFF
--- a/nvmish.sh
+++ b/nvmish.sh
@@ -55,8 +55,8 @@ function __nvmish_install_npm() {
 }
 
 function nvmish_debug () {
-  if [[ "${DEBUG:-}" == "nvmish" ]] ; then
-    echo "DEBUG: ${1:-}"
+  if [[ "${DEBUG}" == "nvmish" ]] ; then
+    echo "DEBUG: ${1}"
   fi
 }
   

--- a/nvmish.sh
+++ b/nvmish.sh
@@ -6,6 +6,8 @@
 # Exit code:
 # 0 Successfully installed and using the desired version
 # 1 No package.json in current directory
+#
+# See debug messages by setting DEBUG=nvmish in your environment
 
 function __nvmish_needs_resolution() {
   local semver=$1
@@ -52,14 +54,17 @@ function __nvmish_install_npm() {
   return $?
 }
 
+function nvmish_debug () {
+  if [[ "${DEBUG:-}" == "nvmish" ]] ; then
+    echo "DEBUG: ${1:-}"
+  fi
+}
+  
+
 function nvmish() {
   if [[ ! -f package.json ]] ; then
-    if [[ "$1" != "chpwd" ]] ; then
-      echo "No package.json found in current directory"
-      return 1
-    else
-      return 0
-    fi
+    nvmish_debug "No package.json in current directory"
+    return 0
   fi
 
   local blessed_nodejs_version=6


### PR DESCRIPTION
Jonah's trying to run the developer start and is currently blocked by the `return 1` that happens by default when invoking `nvmish` bash function.

This PR stops returning non-zero exit code by default when cd'ing into a directory. It also creates a debug function (but only uses it one place).

This _might_ be a major version bump since it changes the default behavior.

cc @goodeggs/shopping-web @jonah-williams 