### PR TITLE
Specify "SubjectAltName" in self-signed SSL cert.

### DIFF
--- a/sslayer
+++ b/sslayer
@@ -22,7 +22,36 @@ die() {
 setup() {
   if [ ! -r cert.pem ]; then
     echo "Generating *.goodeggs.dev wildcard cert:"
-    openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 3650 -sha256 -nodes -subj "/C=US/ST=California/L=San Francisco/O=Good Eggs/OU=Local Development/CN=*.goodeggs.dev" | sed 's//    /'
+  cat > openssl.conf <<EOF
+[ req ]
+distinguished_name = subject
+req_extensions      = req_ext
+x509_extensions     = x509_ext
+
+[ subject ]
+countryName = Country Name (2-letter code)
+countryName_default = US
+stateOrProvinceName = State or Province Name (full name)
+stateOrProvinceName_default = California
+localityName = Locality Name (e.g. city)
+localityName_default = San Francisco
+organizationName = Organization Name
+organizationName_default = Good Eggs
+organizationalUnitName = Organization Unit
+organizationalUnitName_default = Local Development
+commonName = Common Name
+commonName_default = *.goodeggs.dev
+
+[ req_ext ]
+subjectAltName = @alternate_names
+
+[ x509_ext ]
+subjectAltName = @alternate_names
+
+[ alternate_names ]
+DNS.1 = *.goodeggs.dev
+EOF
+    openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 3650 -sha256 -nodes -config openssl.conf | sed 's//    /'
     echo ""
     echo "Now, I will open $PWD/cert.pem in Keychain Access, and you need to make sure SSL is set to Always Trust."
     printf "Ready? [Y] "


### PR DESCRIPTION
Chrome 58 (among others) requires that self-signed certificates specify the hostname(s) to which they apply in the `SubjectAltName` field; previously (as I understand it) the Subject CN entry was used instead, but this is now ignored.

There doesn't appear to be any way to specify this directly in the `openssl` command, so I pulled out all the config into a config file.

See https://textslashplain.com/2017/03/10/chrome-deprecates-subject-cn-matching/.

Also most of this was stolen from http://stackoverflow.com/questions/10175812/how-to-create-a-self-signed-certificate-with-openssl/27931596#27931596.

I tried this locally and it seemed to work (the warning went away).

@bobzoller