### PR TITLE
respect NVMISH_NO_AUTO

### DIFF
--- a/nvmish.sh
+++ b/nvmish.sh
@@ -82,5 +82,5 @@ function nvmish() {
 
 function cd() {
   builtin cd "$@"
-  nvmish
+  [ -z "$NVMISH_NO_AUTO" ] && nvmish
 }


### PR DESCRIPTION
if an environment variable `NVMISH_NO_AUTO` is set, nvmish will be available as a shell function, but not run automatically.

/cc @demands 